### PR TITLE
Fix idempotency on service and provider state

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -73,6 +73,7 @@ def enable_direct
   case mount_status?
   when :enabled
     Chef::Log.debug("#{new_resource} is already enabled - nothing to do")
+    return false
   when :missing, :conflict
     if mount_status? == :conflict
       Chef::Log.error("#{@new_resource} is conflicting with existing mount at #{@new_resource.mount_point}")

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -54,5 +54,6 @@ ruby_block 'autofs.direct' do
     rc.search_file_replace_line(/^\/\-/, "/- /etc/auto.direct --timeout=#{node['automount']['timeout']}")
     rc.write_file
   end
+  not_if { File.read('/etc/auto.master') =~ %r{.*/- /etc/auto.direct --timeout=#{node['automount']['timeout']}.*}m }
   notifies :restart, 'service[autofs]'
 end


### PR DESCRIPTION
Added a return false if already enabled in the provider and a guard to a ruby_block resource to avoid restarting the service at each chef run.