### PR TITLE
NFS mountpoint don't work with ':' prefix

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -40,6 +40,8 @@ def mountline
     target = ":UUID=#{new_resource.device}"
   when :label
     target = ":LABEL=#{new_resource.device}"
+  when :network
+    target = new_resource.device
   end
 
   line = "#{new_resource.mount_point} #{options} #{target}"

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -23,7 +23,7 @@ attribute :name, kind_of: String, name_attribute: true
 
 attribute :mount_point, kind_of: String
 attribute :device, kind_of: String, required: true
-attribute :device_type, kind_of: Symbol, equal_to: [:device, :label, :uuid], default: :device
+attribute :device_type, kind_of: Symbol, equal_to: [:device, :label, :uuid, :network], default: :device
 attribute :fstype, kind_of: String, required: true
 attribute :options, kind_of: [Array, String], default: 'defaults'
 


### PR DESCRIPTION
Ohai !
I need to put this type of conf : 
```
/my_mountpoint -fstype=nfs,defaults,nolock,rsize=8192,wsize=8192 10.10.100.150:/my_nfs_server
```
If I use your LWRP , ```device_type``` always tries to put a ```:``` prefix in front of my NFS path. And it breaks ...

I just added a new ```:network``` device type that don't concat this ```:``` in front of device attribute.
Maybe "network" is not the best suitable name ("empty" type could be ok too), just tell me if you need me to change anything.

Thanks !