### PR TITLE
Added an attribute for autofs package name to support CentOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 bundler_args: --without kitchen_vagrant
 rvm:
-- 2.1.0
+- 2.3.0
 script:
 - rake travis

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,3 +18,4 @@
 #
 
 default['automount']['timeout'] = 600
+default['automount']['autofs_package'] = 'autofs5'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ted@nephilagraphic.com'
 license 'Apache 2.0'
 description 'Installs/Configures automount'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.0'
+version '0.1.1'
 
 %w(ubuntu).each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-package node[:automount][:autofs_package] do
+package node['automount']['autofs_package'] do
   action :install
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-package 'autofs5' do
+package node[:automount][:autofs_package] do
   action :install
 end
 


### PR DESCRIPTION
The autofs package name on CentOS is autofs. It's probably not the only change but it was enough to get the automount LWRP to work for me, so I made it configurable.